### PR TITLE
Update datastore interface to remove dependence on btc wire.MsgTx

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -67,10 +67,10 @@ type Stxos interface {
 
 type Txns interface {
 	// Put a new transaction to the database
-	Put(txn *wire.MsgTx, value, height int, timestamp time.Time, watchOnly bool) error
+	Put(raw []byte, txid string, value, height int, timestamp time.Time, watchOnly bool) error
 
-	// Fetch a raw tx and it's metadata given a hash
-	Get(txid chainhash.Hash) (*wire.MsgTx, Txn, error)
+	// Fetch a tx and it's metadata given a hash
+	Get(txid chainhash.Hash) (Txn, error)
 
 	// Fetch all transactions from the db
 	GetAll(includeWatchOnly bool) ([]Txn, error)


### PR DESCRIPTION
The `Txn` type already has a `Txn.Bytes []byte` field which we can use to return the raw txn data. If we want it in a `*wire.MsgTx` we can decode it where needed. `*wire.MsgTx` works for btc transactions, but doesn't have space for other chains' extra info (e.g. joinsplits for zcash).