### PR TITLE
Modify the btcsuite address requirement to be coin agnostic 

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -2,10 +2,11 @@ package wallet
 
 import (
 	"bytes"
+	"time"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
-	"time"
 )
 
 type CoinType uint32
@@ -15,6 +16,7 @@ const (
 	Litecoin             = 1
 	Zcash                = 133
 	BitcoinCash CoinType = 145
+	Ethereum    CoinType = 88
 )
 
 func (c *CoinType) String() string {
@@ -27,6 +29,8 @@ func (c *CoinType) String() string {
 		return "Zcash"
 	case Litecoin:
 		return "Litecoin"
+	case Ethereum:
+		return "Ethereum"
 	default:
 		return ""
 	}

--- a/datastore.go
+++ b/datastore.go
@@ -9,14 +9,19 @@ import (
 	"github.com/btcsuite/btcd/wire"
 )
 
+type Coin interface {
+	String() string
+	CurrencyCode() string
+}
+
 type CoinType uint32
 
 const (
 	Bitcoin     CoinType = 0
 	Litecoin             = 1
 	Zcash                = 133
-	BitcoinCash CoinType = 145
-	Ethereum    CoinType = 88
+	BitcoinCash          = 145
+	Ethereum             = 60
 )
 
 func (c *CoinType) String() string {
@@ -31,6 +36,23 @@ func (c *CoinType) String() string {
 		return "Litecoin"
 	case Ethereum:
 		return "Ethereum"
+	default:
+		return ""
+	}
+}
+
+func (c *CoinType) CurrencyCode() string {
+	switch *c {
+	case Bitcoin:
+		return "BTC"
+	case BitcoinCash:
+		return "BCH"
+	case Zcash:
+		return "ZEC"
+	case Litecoin:
+		return "LTC"
+	case Ethereum:
+		return "ETH"
 	default:
 		return ""
 	}

--- a/exchange_rates.go
+++ b/exchange_rates.go
@@ -1,0 +1,19 @@
+package wallet
+
+type ExchangeRates interface {
+
+	/* Fetch the exchange rate for the given currency
+	   It is OK if this returns from a cache. */
+	GetExchangeRate(currencyCode string) (float64, error)
+
+	// Update the prices with the current exchange rate before returning
+	GetLatestRate(currencyCode string) (float64, error)
+
+	// Returns all available rates
+	GetAllRates(cacheOK bool) (map[string]float64, error)
+
+	/* Return the number of currency units per coin. For example, in bitcoin
+	   this is 100m satoshi per BTC. This is used when converting from fiat
+	   to the smaller currency unit. */
+	UnitsPerCoin() int
+}

--- a/wallet.go
+++ b/wallet.go
@@ -38,12 +38,6 @@ type Wallet interface {
 	// Parse the address string and return an address interface
 	DecodeAddress(addr string) (btc.Address, error)
 
-	// Turn the given output script into an address
-	ScriptToAddress(script []byte) (btc.Address, error)
-
-	// Turn the given address into an output script
-	AddressToScript(addr btc.Address) ([]byte, error)
-
 	// Returns if the wallet has the key for the given address
 	HasKey(addr btc.Address) bool
 
@@ -87,7 +81,7 @@ type Wallet interface {
 	GenerateMultisigScript(keys []hd.ExtendedKey, threshold int, timeout time.Duration, timeoutKey *hd.ExtendedKey) (addr btc.Address, redeemScript []byte, err error)
 
 	// Add a script to the wallet and get notifications back when coins are received or spent from it
-	AddWatchedScript(script []byte) error
+	AddWatchedAddress(address btc.Address) error
 
 	// Add a callback for incoming transactions
 	AddTransactionListener(func(TransactionCallback))
@@ -136,7 +130,7 @@ type TransactionCallback struct {
 }
 
 type TransactionOutput struct {
-	ScriptPubKey []byte
+	Address      btc.Address
 	Value        int64
 	Index        uint32
 }
@@ -144,7 +138,7 @@ type TransactionOutput struct {
 type TransactionInput struct {
 	OutpointHash       []byte
 	OutpointIndex      uint32
-	LinkedScriptPubKey []byte
+	Address            btc.Address
 	Value              int64
 }
 
@@ -156,7 +150,7 @@ type TransactionRecord struct {
 	Txid         string
 	Index        uint32
 	Value        int64
-	ScriptPubKey string
+	Address      string
 	Spent        bool
 	Timestamp    time.Time
 }


### PR DESCRIPTION
In this change, a new interface 'WalletAddress' is introduced which contains the methods used by the app. The one method 'IsForNet' which is btc specific is excluded.